### PR TITLE
fix: import cookies from next/headers

### DIFF
--- a/nextjs-app/github-oauth/app/login/github/route.ts
+++ b/nextjs-app/github-oauth/app/login/github/route.ts
@@ -1,6 +1,6 @@
 import { auth, githubAuth } from "@/auth/lucia";
 import * as context from "next/headers";
-
+import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 
 export const GET = async (request: NextRequest) => {


### PR DESCRIPTION
Import `cookies` from next/headers to fix the error message: `cookies is not defined`