### PR TITLE
Update astro examples to Astro 4 and astrojs/node 8

### DIFF
--- a/astro/email-and-password/package.json
+++ b/astro/email-and-password/package.json
@@ -11,9 +11,9 @@
 		"astro": "astro"
 	},
 	"dependencies": {
-		"@astrojs/node": "^5.3.0",
+		"@astrojs/node": "^8.0.0",
 		"@lucia-auth/adapter-sqlite": "latest",
-		"astro": "^3.0.0",
+		"astro": "^4.2.4",
 		"better-sqlite3": "^8.4.0",
 		"kysely": "^0.25.0",
 		"lucia": "latest"

--- a/astro/email-and-password/src/pages/email-verification/[token].ts
+++ b/astro/email-and-password/src/pages/email-verification/[token].ts
@@ -3,7 +3,7 @@ import { validateEmailVerificationToken } from "../../lib/token";
 
 import type { APIRoute } from "astro";
 
-export const get: APIRoute = async ({ params, locals }) => {
+export const GET: APIRoute = async ({ params, locals }) => {
 	const { token } = params;
 	if (!token) {
 		return new Response(null, {

--- a/astro/email-and-password/src/pages/logout.ts
+++ b/astro/email-and-password/src/pages/logout.ts
@@ -2,7 +2,7 @@ import { auth } from "../lib/lucia";
 
 import type { APIRoute } from "astro";
 
-export const post: APIRoute = async (context) => {
+export const POST: APIRoute = async (context) => {
 	const session = await context.locals.auth.validate();
 	if (!session) {
 		return new Response("Unauthorized", {

--- a/astro/github-oauth/package.json
+++ b/astro/github-oauth/package.json
@@ -11,10 +11,10 @@
 		"astro": "astro"
 	},
 	"dependencies": {
-		"@astrojs/node": "^5.3.0",
+		"@astrojs/node": "^8.0.0",
 		"@lucia-auth/adapter-sqlite": "latest",
 		"@lucia-auth/oauth": "latest",
-		"astro": "^3.0.0",
+		"astro": "^4.2.4",
 		"better-sqlite3": "^8.4.0",
 		"lucia": "latest"
 	},

--- a/astro/github-oauth/src/pages/login/github/callback.ts
+++ b/astro/github-oauth/src/pages/login/github/callback.ts
@@ -3,7 +3,7 @@ import { OAuthRequestError } from "@lucia-auth/oauth";
 
 import type { APIRoute } from "astro";
 
-export const get: APIRoute = async (context) => {
+export const GET: APIRoute = async (context) => {
 	const session = await context.locals.auth.validate();
 	if (session) {
 		return context.redirect("/", 302); // redirect to profile page

--- a/astro/github-oauth/src/pages/login/github/index.ts
+++ b/astro/github-oauth/src/pages/login/github/index.ts
@@ -2,7 +2,7 @@ import { githubAuth } from "../../../lib/lucia";
 
 import type { APIRoute } from "astro";
 
-export const get: APIRoute = async (context) => {
+export const GET: APIRoute = async (context) => {
 	const session = await context.locals.auth.validate();
 	if (session) {
 		return context.redirect("/", 302); // redirect to profile page

--- a/astro/github-oauth/src/pages/logout.ts
+++ b/astro/github-oauth/src/pages/logout.ts
@@ -2,7 +2,7 @@ import { auth } from "../lib/lucia";
 
 import type { APIRoute } from "astro";
 
-export const post: APIRoute = async (context) => {
+export const POST: APIRoute = async (context) => {
 	const session = await context.locals.auth.validate();
 	if (!session) {
 		return new Response("Unauthorized", {

--- a/astro/username-and-password/package.json
+++ b/astro/username-and-password/package.json
@@ -11,9 +11,9 @@
 		"astro": "astro"
 	},
 	"dependencies": {
-		"@astrojs/node": "^5.3.0",
+		"@astrojs/node": "^8.0.0",
 		"@lucia-auth/adapter-sqlite": "latest",
-		"astro": "^3.0.0",
+		"astro": "^4.2.4",
 		"better-sqlite3": "^8.4.0",
 		"lucia": "latest"
 	},

--- a/astro/username-and-password/src/pages/logout.ts
+++ b/astro/username-and-password/src/pages/logout.ts
@@ -2,16 +2,16 @@ import { auth } from "../lib/lucia";
 
 import type { APIRoute } from "astro";
 
-export const post: APIRoute = async (context) => {
-	const session = await context.locals.auth.validate();
-	if (!session) {
-		return new Response("Unauthorized", {
-			status: 401
-		});
-	}
-	// make sure to invalidate the current session!
-	await auth.invalidateSession(session.sessionId);
-	// delete session cookie
-	context.locals.auth.setSession(null);
-	return context.redirect("/login", 302);
+export const POST: APIRoute = async (context) => {
+  const session = await context.locals.auth.validate();
+  if (!session) {
+    return new Response("Unauthorized", {
+      status: 401
+    });
+  }
+  // make sure to invalidate the current session!
+  await auth.invalidateSession(session.sessionId);
+  // delete session cookie
+  context.locals.auth.setSession(null);
+  return context.redirect("/login", 302);
 };


### PR DESCRIPTION
Hi! 👋 

Following up #20, this PR updates the Astro examples to v4 and astrojs/node v8

I believe the only change that needs to be made was renaming the HTTP method names to uppercase, as Astro v4.0 removes support for lowercase names:
👉  https://docs.astro.build/en/guides/upgrade-to/v4/#removed-lowercase-http-method-names

All the examples are working as expected:

## Github OAuth
https://github.com/lucia-auth/examples/assets/22222078/6c8d281d-74f1-4c2c-a389-bb6ff825d27c

## Email and password
https://github.com/lucia-auth/examples/assets/22222078/59744eaf-e008-49a5-9438-17a99c831f31

## Username and password
https://github.com/lucia-auth/examples/assets/22222078/b5aa672d-4bbf-43b8-881d-2bcd0b1b8be2

