### PR TITLE
fix(nuxt): use `$fetch` and `event.$fetch` for requests

### DIFF
--- a/nuxt/github-oauth/middleware/auth.global.ts
+++ b/nuxt/github-oauth/middleware/auth.global.ts
@@ -1,7 +1,7 @@
 export default defineNuxtRouteMiddleware(async () => {
 	const user = useUser();
-	const { data } = await useFetch("/api/user");
-	if (data.value) {
-		user.value = data.value;
+	const data = await useRequestFetch()("/api/user");
+	if (data) {
+		user.value = data;
 	}
 });

--- a/nuxt/github-oauth/pages/index.vue
+++ b/nuxt/github-oauth/pages/index.vue
@@ -6,10 +6,10 @@ definePageMeta({
 const user = useAuthenticatedUser();
 
 async function logout() {
-	await useFetch("/api/logout", {
+	await $fetch("/api/logout", {
 		method: "POST"
 	});
-	navigateTo("/login");
+	await navigateTo("/login");
 }
 </script>
 

--- a/nuxt/username-and-password/middleware/auth.global.ts
+++ b/nuxt/username-and-password/middleware/auth.global.ts
@@ -1,7 +1,7 @@
 export default defineNuxtRouteMiddleware(async () => {
 	const user = useUser();
-	const { data } = await useFetch("/api/user");
-	if (data.value) {
-		user.value = data.value;
+	const data = await useRequestFetch()("/api/user");
+	if (data) {
+		user.value = data;
 	}
 });

--- a/nuxt/username-and-password/pages/index.vue
+++ b/nuxt/username-and-password/pages/index.vue
@@ -6,10 +6,10 @@ definePageMeta({
 const user = useAuthenticatedUser();
 
 async function logout() {
-	await useFetch("/api/logout", {
+	await $fetch("/api/logout", {
 		method: "POST"
 	});
-	navigateTo("/login");
+	await navigateTo("/login");
 }
 </script>
 

--- a/nuxt/username-and-password/pages/login.vue
+++ b/nuxt/username-and-password/pages/login.vue
@@ -2,14 +2,14 @@
 const error = ref<string | null>(null);
 
 async function login(e: Event) {
-	const result = await useFetch("/api/login", {
-		method: "POST",
-		body: new FormData(e.target as HTMLFormElement)
-	});
-	if (result.error.value) {
-		error.value = result.error.value.data?.message ?? null;
-	} else {
+	try {
+		await $fetch("/api/login", {
+			method: "POST",
+			body: new FormData(e.target as HTMLFormElement)
+		});
 		await navigateTo("/");
+	} catch (err) {
+		error.value = err.data?.message ?? null;
 	}
 }
 </script>

--- a/nuxt/username-and-password/pages/signup.vue
+++ b/nuxt/username-and-password/pages/signup.vue
@@ -2,14 +2,14 @@
 const error = ref<string | null>(null);
 
 async function signup(e: Event) {
-	const result = await useFetch("/api/signup", {
-		method: "POST",
-		body: new FormData(e.target as HTMLFormElement)
-	});
-	if (result.error.value) {
-		error.value = result.error.value.data?.message ?? null;
-	} else {
+	try {
+		await $fetch("/api/signup", {
+			method: "POST",
+			body: new FormData(e.target as HTMLFormElement)
+		});
 		await navigateTo("/");
+	} catch (err) {
+		error.value = err.data?.message ?? null;
 	}
 }
 </script>


### PR DESCRIPTION
Some slight refactors to avoid using `useFetch` to perform fetches. (It's a composable that should only be called in Nuxt plugins or component setup functions.)