### PR TITLE
Correct validation error message in examples

### DIFF
--- a/express/username-and-password/routes/login.ts
+++ b/express/username-and-password/routes/login.ts
@@ -21,7 +21,7 @@ loginRouter.post("/login", async (req, res) => {
 	if (!username || username.length < 3 || username.length > 31 || !/^[a-z0-9_-]+$/.test(username)) {
 		const html = await renderPage({
 			username_value: username ?? "",
-			error: "Invalid password"
+			error: "Invalid username"
 		});
 		return res.setHeader("Content-Type", "text/html").status(400).send(html);
 	}

--- a/express/username-and-password/routes/signup.ts
+++ b/express/username-and-password/routes/signup.ts
@@ -21,7 +21,7 @@ signupRouter.post("/signup", async (req, res) => {
 	if (!username || username.length < 3 || username.length > 31 || !/^[a-z0-9_-]+$/.test(username)) {
 		const html = await renderPage({
 			username_value: username ?? "",
-			error: "Invalid password"
+			error: "Invalid username"
 		});
 		return res.setHeader("Content-Type", "text/html").status(400).send(html);
 	}

--- a/hono/username-and-password/routes/login.ts
+++ b/hono/username-and-password/routes/login.ts
@@ -27,7 +27,7 @@ loginRouter.post("/login", async (c) => {
 	if (!username || username.length < 3 || username.length > 31 || !/^[a-z0-9_-]+$/.test(username)) {
 		const html = await renderPage({
 			username_value: username ?? "",
-			error: "Invalid password"
+			error: "Invalid username"
 		});
 		return c.html(html, 200);
 	}

--- a/hono/username-and-password/routes/signup.ts
+++ b/hono/username-and-password/routes/signup.ts
@@ -28,7 +28,7 @@ signupRouter.post("/signup", async (c) => {
 	if (!username || username.length < 3 || username.length > 31 || !/^[a-z0-9_-]+$/.test(username)) {
 		const html = await renderPage({
 			username_value: username ?? "",
-			error: "Invalid password"
+			error: "Invalid username"
 		});
 		return c.html(html, 200);
 	}


### PR DESCRIPTION
Fixed small typos in Express and Hono examples (username validation error previously said "password")