### PR TITLE
fix: solidstart/github-oauth: update to current versions

### DIFF
--- a/solidstart/github-oauth/package.json
+++ b/solidstart/github-oauth/package.json
@@ -7,19 +7,20 @@
 		"start": "node ./.output/server/index.mjs"
 	},
 	"dependencies": {
-		"@lucia-auth/adapter-sqlite": "^3.0.0",
-		"@solidjs/router": "^0.10.5",
-		"@solidjs/start": "^0.4.2",
-		"arctic": "^0.10.2",
-		"better-sqlite3": "^9.2.2",
-		"lucia": "^3.2.0",
-		"solid-js": "^1.8.7",
-		"vinxi": "0.0.54"
+		"@lucia-auth/adapter-sqlite": "^3.0.2",
+		"@solidjs/router": "^0.14.10",
+		"@solidjs/start": "^1.0.9",
+		"arctic": "^1.9.2",
+		"better-sqlite3": "^9.6.0",
+		"lucia": "^3.2.1",
+		"solid-js": "^1.9.2",
+		"vinxi": "^0.4.3"
 	},
 	"engines": {
 		"node": ">=18"
 	},
 	"devDependencies": {
-		"@types/better-sqlite3": "^7.6.8"
+		"@types/better-sqlite3": "^7.6.8",
+		"typescript": "^5.6.3"
 	}
 }

--- a/solidstart/github-oauth/src/app.tsx
+++ b/solidstart/github-oauth/src/app.tsx
@@ -1,5 +1,5 @@
 import { Router } from "@solidjs/router";
-import { FileRoutes } from "@solidjs/start";
+import { FileRoutes } from "@solidjs/start/router";
 import { Suspense } from "solid-js";
 
 export default function App() {

--- a/solidstart/github-oauth/src/entry-client.tsx
+++ b/solidstart/github-oauth/src/entry-client.tsx
@@ -1,3 +1,3 @@
 import { mount, StartClient } from "@solidjs/start/client";
 
-mount(() => <StartClient />, document.getElementById("app"));
+mount(() => <StartClient />, document.getElementById("app")!);

--- a/solidstart/github-oauth/src/lib/utils.ts
+++ b/solidstart/github-oauth/src/lib/utils.ts
@@ -4,8 +4,8 @@ import { getRequestEvent } from "solid-js/web";
 export const getAuthenticatedUser = cache(async () => {
 	"use server";
 	const event = getRequestEvent()!;
-	if (!event.context.user) {
+	if (!event.locals.user) {
 		throw redirect("/login");
 	}
-	return event.context.user;
+	return event.locals.user;
 }, "user");

--- a/solidstart/github-oauth/src/middleware.ts
+++ b/solidstart/github-oauth/src/middleware.ts
@@ -1,39 +1,41 @@
-import { createMiddleware, appendHeader, getCookie, getHeader } from "@solidjs/start/server";
+import { createMiddleware} from "@solidjs/start/middleware";
 import { Session, User, verifyRequestOrigin } from "lucia";
 import { lucia } from "./lib/auth";
+import { appendHeader, getCookie, getHeader } from "vinxi/http";
+import { FetchEvent } from "@solidjs/start/server";
 
 export default createMiddleware({
-	onRequest: async (event) => {
-		if (event.node.req.method !== "GET") {
-			const originHeader = getHeader(event, "Origin") ?? null;
-			const hostHeader = getHeader(event, "Host") ?? null;
+	onRequest: [ async (event: FetchEvent) => {
+		if (event.request.method !== "GET") {
+			const originHeader = getHeader("Origin") ?? null;
+			const hostHeader = getHeader( "Host") ?? null;
 			if (!originHeader || !hostHeader || !verifyRequestOrigin(originHeader, [hostHeader])) {
-				event.node.res.writeHead(403).end();
+				event.response.status = 403;
 				return;
 			}
 		}
 
-		const sessionId = getCookie(event, lucia.sessionCookieName) ?? null;
+		const sessionId = getCookie(lucia.sessionCookieName) ?? null;
 		if (!sessionId) {
-			event.context.session = null;
-			event.context.user = null;
+			event.locals.session = null;
+			event.locals.user = null;
 			return;
 		}
 
 		const { session, user } = await lucia.validateSession(sessionId);
 		if (session && session.fresh) {
-			appendHeader(event, "Set-Cookie", lucia.createSessionCookie(session.id).serialize());
+			appendHeader("Set-Cookie", lucia.createSessionCookie(session.id).serialize());
 		}
 		if (!session) {
-			appendHeader(event, "Set-Cookie", lucia.createBlankSessionCookie().serialize());
+			appendHeader("Set-Cookie", lucia.createBlankSessionCookie().serialize());
 		}
-		event.context.session = session;
-		event.context.user = user;
-	}
+		event.locals.session = session;
+		event.locals.user = user;
+	}]
 });
 
-declare module "vinxi/server" {
-	interface H3EventContext {
+declare module "@solidjs/start/server" {
+	interface RequestEventLocals {
 		user: User | null;
 		session: Session | null;
 	}

--- a/solidstart/github-oauth/src/routes/index.tsx
+++ b/solidstart/github-oauth/src/routes/index.tsx
@@ -1,11 +1,11 @@
 import { action, createAsync, redirect } from "@solidjs/router";
 import { getRequestEvent } from "solid-js/web";
-import { appendHeader } from "@solidjs/start/server";
+import { appendHeader } from "vinxi/http";
 import { lucia } from "~/lib/auth";
 import { getAuthenticatedUser } from "~/lib/utils";
 
 export default function Index() {
-	const user = createAsync(getAuthenticatedUser);
+	const user = createAsync(() => getAuthenticatedUser());
 	return (
 		<>
 			<h1>Hi, {user()?.username}!</h1>
@@ -20,10 +20,10 @@ export default function Index() {
 const logout = action(async () => {
 	"use server";
 	const event = getRequestEvent()!;
-	if (!event.context.session) {
+	if (!event.locals.session) {
 		return new Error("Unauthorized");
 	}
-	await lucia.invalidateSession(event.context.session.id);
-	appendHeader(event, "Set-Cookie", lucia.createBlankSessionCookie().serialize());
+	await lucia.invalidateSession(event.locals.session.id);
+	appendHeader("Set-Cookie", lucia.createBlankSessionCookie().serialize());
 	throw redirect("/login");
 });

--- a/solidstart/github-oauth/src/routes/login/github/index.ts
+++ b/solidstart/github-oauth/src/routes/login/github/index.ts
@@ -1,4 +1,4 @@
-import { sendRedirect, setCookie } from "@solidjs/start/server";
+import { sendRedirect, setCookie } from "vinxi/http";
 import { generateState } from "arctic";
 import { github } from "~/lib/auth";
 
@@ -8,12 +8,12 @@ export async function GET(event: APIEvent) {
 	const state = generateState();
 	const url = await github.createAuthorizationURL(state);
 
-	setCookie(event, "github_oauth_state", state, {
+	setCookie("github_oauth_state", state, {
 		path: "/",
 		secure: process.env.NODE_ENV === "production",
 		httpOnly: true,
 		maxAge: 60 * 10,
 		sameSite: "lax"
 	});
-	return sendRedirect(event, url.toString());
+	return sendRedirect(url.toString());
 }

--- a/solidstart/github-oauth/vite.config.ts
+++ b/solidstart/github-oauth/vite.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from "@solidjs/start/config";
 
 export default defineConfig({
-	start: {
-		middleware: "./src/middleware.ts"
-	}
+	middleware: "./src/middleware.ts"
 });


### PR DESCRIPTION
The current `main` version of `solidstart/github-oauth` does not run with the current `main` code. This PR fixes that so that the example runs correctly, making the minimum necessary changes to bring the code up-to-date. The changes were manually tested and confirmed.